### PR TITLE
Colorizing debug messages

### DIFF
--- a/gempyrelib/CMakeLists.txt
+++ b/gempyrelib/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(USE_PYTHON_UI)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE -DUSE_PYTHON_UI)
+    add_compile_definitions(USE_PYTHON_UI)
 endif()
 
 message("compiler is ${CMAKE_CXX_COMPILER_ID}")

--- a/gempyrelib/CMakeLists.txt
+++ b/gempyrelib/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(USE_PYTHON_UI)
-    add_compile_definitions(USE_PYTHON_UI)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DUSE_PYTHON_UI)
 endif()
 
 message("compiler is ${CMAKE_CXX_COMPILER_ID}")

--- a/gempyrelib/src/logging.cpp
+++ b/gempyrelib/src/logging.cpp
@@ -82,6 +82,7 @@ std::string GempyreUtils::to_str(LogLevel l) {
         {LogLevel::Fatal, "\e[4;31mFATAL\e[0m"},//Dark red with underline
         {LogLevel::Debug_Trace, "\e[0;103m\e[1;90mTRACE\e[0m"}//Yello background + Black text
     };
+    return m.at(l);
 #endif
 }
 

--- a/gempyrelib/src/logging.cpp
+++ b/gempyrelib/src/logging.cpp
@@ -61,6 +61,7 @@ GempyreUtils::LogLevel GempyreUtils::log_level() {
 }
 
 std::string GempyreUtils::to_str(LogLevel l) {
+#ifdef WINDOWS_OS
     const std::unordered_map<LogLevel, std::string> m = {
         {LogLevel::None, "NONE"},
         {LogLevel::Error, "ERROR"},
@@ -70,6 +71,17 @@ std::string GempyreUtils::to_str(LogLevel l) {
         {LogLevel::Fatal, "FATAL"},
         {LogLevel::Debug_Trace, "TRACE"}
     };
+#else
+        const std::unordered_map<LogLevel, std::string> m = {
+        {LogLevel::None, "NONE"},
+        {LogLevel::Error, "\e[1;31mERROR\e[0m"},//Red text
+        {LogLevel::Warning, "\e[1;48:5:166mWARNING\e[0m"},//Orange background
+        {LogLevel::Info, "\e[0;106m\e[1;90mINFO\e[0m"},//Cyan background + Black text
+        {LogLevel::Debug, "\e[0;103m\e[1;90mDEBUG\e[0m"},//Yello background + Black text
+        {LogLevel::Fatal, "\e[4;31mFATAL\e[0m"},//Dark red with underline
+        {LogLevel::Debug_Trace, "\e[0;103m\e[1;90mTRACE\e[0m"}//Yello background + Black text
+    };
+#endif
     return m.at(l);
 }
 

--- a/gempyrelib/src/logging.cpp
+++ b/gempyrelib/src/logging.cpp
@@ -61,7 +61,6 @@ GempyreUtils::LogLevel GempyreUtils::log_level() {
 }
 
 std::string GempyreUtils::to_str(LogLevel l) {
-    const std::unordered_map<LogLevel, std::string> m = {
 #ifdef WINDOWS_OS
     const std::unordered_map<LogLevel, std::string> m = {
         {LogLevel::None, "NONE"},

--- a/gempyrelib/src/logging.cpp
+++ b/gempyrelib/src/logging.cpp
@@ -62,6 +62,8 @@ GempyreUtils::LogLevel GempyreUtils::log_level() {
 
 std::string GempyreUtils::to_str(LogLevel l) {
     const std::unordered_map<LogLevel, std::string> m = {
+#ifdef WINDOWS_OS
+    const std::unordered_map<LogLevel, std::string> m = {
         {LogLevel::None, "NONE"},
         {LogLevel::Error, "ERROR"},
         {LogLevel::Warning, "WARNING"},
@@ -70,7 +72,17 @@ std::string GempyreUtils::to_str(LogLevel l) {
         {LogLevel::Fatal, "FATAL"},
         {LogLevel::Debug_Trace, "TRACE"}
     };
-    return m.at(l);
+#else
+        const std::unordered_map<LogLevel, std::string> m = {
+        {LogLevel::None, "NONE"},
+        {LogLevel::Error, "\e[1;31mERROR\e[0m"},//Red text
+        {LogLevel::Warning, "\e[1;48:5:166mWARNING\e[0m"},//Orange background
+        {LogLevel::Info, "\e[0;106m\e[1;90mINFO\e[0m"},//Cyan background + Black text
+        {LogLevel::Debug, "\e[0;103m\e[1;90mDEBUG\e[0m"},//Yello background + Black text
+        {LogLevel::Fatal, "\e[4;31mFATAL\e[0m"},//Dark red with underline
+        {LogLevel::Debug_Trace, "\e[0;103m\e[1;90mTRACE\e[0m"}//Yello background + Black text
+    };
+#endif
 }
 
 std::string LogWriter::header(LogLevel logLevel) {

--- a/gempyrelib/src/logging.cpp
+++ b/gempyrelib/src/logging.cpp
@@ -72,7 +72,7 @@ std::string GempyreUtils::to_str(LogLevel l) {
         {LogLevel::Debug_Trace, "TRACE"}
     };
 #else
-        const std::unordered_map<LogLevel, std::string> m = {
+    const std::unordered_map<LogLevel, std::string> m = {
         {LogLevel::None, "NONE"},
         {LogLevel::Error, "\e[1;31mERROR\e[0m"},//Red text
         {LogLevel::Warning, "\e[1;48:5:166mWARNING\e[0m"},//Orange background

--- a/gempyrelib/src/logging.cpp
+++ b/gempyrelib/src/logging.cpp
@@ -61,7 +61,6 @@ GempyreUtils::LogLevel GempyreUtils::log_level() {
 }
 
 std::string GempyreUtils::to_str(LogLevel l) {
-#ifdef WINDOWS_OS
     const std::unordered_map<LogLevel, std::string> m = {
         {LogLevel::None, "NONE"},
         {LogLevel::Error, "ERROR"},
@@ -71,17 +70,6 @@ std::string GempyreUtils::to_str(LogLevel l) {
         {LogLevel::Fatal, "FATAL"},
         {LogLevel::Debug_Trace, "TRACE"}
     };
-#else
-        const std::unordered_map<LogLevel, std::string> m = {
-        {LogLevel::None, "NONE"},
-        {LogLevel::Error, "\e[1;31mERROR\e[0m"},//Red text
-        {LogLevel::Warning, "\e[1;48:5:166mWARNING\e[0m"},//Orange background
-        {LogLevel::Info, "\e[0;106m\e[1;90mINFO\e[0m"},//Cyan background + Black text
-        {LogLevel::Debug, "\e[0;103m\e[1;90mDEBUG\e[0m"},//Yello background + Black text
-        {LogLevel::Fatal, "\e[4;31mFATAL\e[0m"},//Dark red with underline
-        {LogLevel::Debug_Trace, "\e[0;103m\e[1;90mTRACE\e[0m"}//Yello background + Black text
-    };
-#endif
     return m.at(l);
 }
 


### PR DESCRIPTION
colorizing debug messages will help the developer to distinguish between messages a lot easier. Specially warnings and error messages.

this MR will add a background color to messages that is disabled by default (`DEBUG`, `TRACE`, `WARNING`, `INFO`). the other ones just have text color (`ERROR`, `FATAL`).

This is how the output looks like in vscod(e)(ium)/Arch Linux:


![Screenshot_20230130_122330](https://user-images.githubusercontent.com/37829730/215431002-0d3a3e54-ae80-4dc3-839c-6dc4af73ec3a.png)

