### PR TITLE
Fix title parameter in `Ui` constructor

### DIFF
--- a/gempyrelib/src/core.cpp
+++ b/gempyrelib/src/core.cpp
@@ -272,7 +272,7 @@ Ui::Ui(const Filemap& filemap,
        const std::string& root) : Ui(filemap, indexHtml, port, root,
             {
     // add only if valid
-    {!title.empty() ? TITLE_KEY : "", title},
+    {!title.empty() ? TITLE_KEY : "", GempyreUtils::qq(title)},
     {flags != 0 ? FLAGS_KEY : "", std::to_string(flags)},
     {width > 0 ? WIDTH_KEY : "", std::to_string(width)},
     {height > 0 ? HEIGHT_KEY : "", std::to_string(height)},


### PR DESCRIPTION
if you type any text that has a space (` `) or tab (`    `) the library will break. this patch will fix the issue. 

I think when we provide raw parameters to the constructor directly, it shouldn't add anything. we just need to add `qq()`, to that constructor where the library tries to add parameters automatically.

`mywindow w(Resourcesh,"index.html","Some Cool App",1152,648);`
