### PR TITLE
 Avoid printing the entire source code in Python UI as a "log message"

### DIFF
--- a/gempyrelib/src/core.cpp
+++ b/gempyrelib/src/core.cpp
@@ -377,9 +377,11 @@ bool Ui::startListen(const std::string& indexHtml, const std::unordered_map<std:
     m_ui->set(State::RUNNING);
 
     const auto& [appui, cmd_params] = guiCmdLine(indexHtml, listen_port, parameters);
-
+#ifdef USE_PYTHON_UI
+    GempyreUtils::log(GempyreUtils::LogLevel::Debug, "Python gui started with these parameters: ", cmd_params);
+#else
     GempyreUtils::log(GempyreUtils::LogLevel::Debug, "gui cmd:", appui, cmd_params);
-
+#endif
 
 #if defined (ANDROID_OS)
     const auto result = androidLoadUi(appui + " " + cmd_params);

--- a/gempyrelib/src/core.cpp
+++ b/gempyrelib/src/core.cpp
@@ -376,11 +376,13 @@ bool Ui::startListen(const std::string& indexHtml, const std::unordered_map<std:
     m_ui->set(State::RUNNING);
 
     const auto& [appui, cmd_params] = guiCmdLine(indexHtml, listen_port, parameters);
-#ifdef USE_PYTHON_UI
-    GempyreUtils::log(GempyreUtils::LogLevel::Debug, "Python gui started with these parameters:", cmd_params);
-#else
-    GempyreUtils::log(GempyreUtils::LogLevel::Debug, "gui cmd:", appui, cmd_params);
-#endif
+    if(appui.length()>20) {
+        std::string_view clipped_appui(appui.c_str(),20) ;//for logging
+        GempyreUtils::log(GempyreUtils::LogLevel::Debug, "gui_cmd:", clipped_appui,"(...)", cmd_params);
+    }
+    else {
+        GempyreUtils::log(GempyreUtils::LogLevel::Debug, "gui cmd:", appui, cmd_params);
+    }
 
 #if defined (ANDROID_OS)
     const auto result = androidLoadUi(appui + " " + cmd_params);

--- a/gempyrelib/src/core.cpp
+++ b/gempyrelib/src/core.cpp
@@ -184,9 +184,8 @@ static std::tuple<std::string, std::string> guiCmdLine(const std::string& indexH
             if(py_data != Gempyrejsh.end()) {
                 const auto py_code = Base64::decode(py_data->second);
                 const std::string py = GempyreUtils::join(py_code);
-                const auto call_param = std::string("-c \"") + py + "\" ";
-                return {*py3, call_param
-                            + GempyreUtils::join<std::vector<std::string>>({
+                const auto call_param = " -c \"" + py + "\" ";
+                return {*py3 + call_param, GempyreUtils::join<std::vector<std::string>>({
                                      "--gempyre-url=" + url,
                                      join(param_map, WIDTH_KEY, "--gempyre-width="),
                                      join(param_map, HEIGHT_KEY,"--gempyre-height="),
@@ -378,7 +377,7 @@ bool Ui::startListen(const std::string& indexHtml, const std::unordered_map<std:
 
     const auto& [appui, cmd_params] = guiCmdLine(indexHtml, listen_port, parameters);
 #ifdef USE_PYTHON_UI
-    GempyreUtils::log(GempyreUtils::LogLevel::Debug, "Python gui started with these parameters: ", cmd_params);
+    GempyreUtils::log(GempyreUtils::LogLevel::Debug, "Python gui started with these parameters:", cmd_params);
 #else
     GempyreUtils::log(GempyreUtils::LogLevel::Debug, "gui cmd:", appui, cmd_params);
 #endif


### PR DESCRIPTION
Log messages intended to be a brief explanation of internal events to inform us about whats is actually going in the program. printing the entire source code of python UI doesn't help at all. It only pollutes the Terminal.

Like this:
![Screenshot_20230307_111502](https://user-images.githubusercontent.com/37829730/223364183-b0a23292-ad6e-4f22-98f2-af58d805b08b.png)

this fix instead only shows the parameters and not the source code.